### PR TITLE
Add support for Fishing Buddy and Weak Auras addon groups

### DIFF
--- a/ACP.lua
+++ b/ACP.lua
@@ -38,6 +38,10 @@ function ACP:SpecialCaseName(name)
         return name:sub(2, -1)
     elseif name == "ShadowedUF_Options" then
         return "ShadowedUnitFrames_Options"
+    elseif name == "FB_TrackingFrame" then
+        return "FishingBuddy_TrackingFrame"
+    elseif name:match("WeakAuras") then
+        return name:gsub("WeakAuras(%w+)", "WeakAuras_%1")
     end
 
     return name


### PR DESCRIPTION
The Fishing Budding Tracking Frame and WeakAuras addons use a different naming scheme so they are incorrectly grouped in the panel. This adds support for both addons to correctly group them. This is my first time writing any Lua code, so let me know if theres a better way to solve either problem!